### PR TITLE
A few changes

### DIFF
--- a/App.config
+++ b/App.config
@@ -3,4 +3,7 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>
+    <runtime>
+        <loadFromRemoteSources enabled="true"/>
+    </runtime>
 </configuration>

--- a/CommandLine.cs
+++ b/CommandLine.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace AMP.DedicatedServer {
+    public class CommandLine {
+        private Dictionary<string, string> args = new Dictionary<string, string>();
+        public CommandLine(string[] args) {
+            if (UsingOldCommandLine(args)) {
+                if (args.Length > 0) {
+                    this.args["port"] = args[0];
+                }
+
+                if (args.Length > 1) {
+                    this.args["max_players"] = args[1];
+                }
+            } else {
+                for (int i=0; i<args.Length; i++) {
+                    if (args[i].StartsWith("-")) {
+                        if ((args.Length - 1) > i) {
+                            this.args[args[i].Substring(1)] = args[i + 1];
+                        } else {
+                            this.args[args[i].Substring(1)] = "";
+                        }
+                    }
+                }
+            }
+        }
+
+        public bool HasArg(string name) {
+            return args.ContainsKey(name);
+        }
+
+        public string GetArg(string name)
+        {
+            return args[name];
+        }
+
+        private bool UsingOldCommandLine(string[] args) {
+            if (args.Length > 0) {
+                for (int i=0; i<args.Length; i++) {
+                    if (args[i].StartsWith("-")) {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/Commands/SpawnItemCommand.cs
+++ b/Commands/SpawnItemCommand.cs
@@ -5,7 +5,7 @@ namespace AMP.DedicatedServer.Commands {
     internal class SpawnItemCommand : CommandHandler {
 
         public override string[] ALIASES => new string[] { "si", "spawnitem" };
-        public override string   HELP    => "Shows the status of the server.";
+        public override string   HELP    => "Spawns the given Item at the given position";
 
         public override string Process(string[] args) {
             if(args.Length == 4) {

--- a/Server.csproj
+++ b/Server.csproj
@@ -6,7 +6,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{86206478-6BB2-4A8F-8275-10EA44897D9D}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <RootNamespace>AMP.DedicatedServer</RootNamespace>
+    <RootNamespace>AMP.Bootstrap</RootNamespace>
     <AssemblyName>AMP_Server</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
@@ -51,7 +51,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <StartupObject>AMP.DedicatedServer.ServerInit</StartupObject>
+    <StartupObject>AMP.Bootstrap.Launcher</StartupObject>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Netamite">
@@ -75,6 +75,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CommandHandler.cs" />
+    <Compile Include="CommandLine.cs" />
     <Compile Include="Commands\UnbanCommand.cs" />
     <Compile Include="Commands\BanCommand.cs" />
     <Compile Include="Commands\ListCommand.cs" />
@@ -90,6 +91,7 @@
     <Compile Include="Functions\CreatureUtil.cs" />
     <Compile Include="Plugins\PluginConfigLoader.cs" />
     <Compile Include="Plugins\PluginConfig.cs" />
+    <Compile Include="ServerBootstrap.cs" />
     <Compile Include="ServerConfig.cs" />
     <Compile Include="Data\Defines.cs" />
     <Compile Include="Functions\ItemUtil.cs" />

--- a/ServerBootstrap.cs
+++ b/ServerBootstrap.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using System.Threading;
+using AMP.DedicatedServer;
+
+namespace AMP.Bootstrap {
+    class Launcher {
+        static void Main(string[] args) {
+            Main(new CommandLine(args));
+        }
+
+        static void Main(CommandLine cmd) {
+            try {
+                Rename("ZZZ_AMP.dll", "AMP.dll");
+                Rename("ZZZ_AMP.pdb", "AMP.pdb");
+
+                CheckFile("Netamite.dll");
+                CheckFile("Netamite.Steam.dll");
+                CheckFile("Netamite.Unity.dll");
+                CheckFile("Newtonsoft.Json.dll");
+                CheckFile("Unity.ResourceManager.dll");
+                CheckFile("UnityEngine.CoreModule.dll");
+                CheckFile("UnityEngine.PhysicsModule.dll");
+                CheckFile("UnityEngine.SharedInternalsModule.dll");
+                CheckFile("ThunderRoad.dll");
+                CheckFile("ThunderRoad.Manikin.dll");
+
+                ServerInit.Start(cmd);
+            } catch (Exception ex) {
+                Console.WriteLine(ex.ToString());
+                Console.WriteLine("\nError: " + ex.Message);
+                Console.WriteLine("An error occurred. See latest error.txt entry");
+                using (StreamWriter writer = new StreamWriter("error.txt", true)) {
+                    writer.WriteLine("\n--- " + DateTime.Now.ToString() + " ---");
+                    writer.Write(ex.ToString());
+                }
+
+                Thread.Sleep(3000);
+            }
+        }
+
+        public static void Rename(string file, string output) {
+            bool output_exists = File.Exists(output);
+            if (File.Exists(file) && !output_exists) {
+                File.Move(file, output);
+                Console.WriteLine("Found " + file + " renamed it to " + output);
+            } else if (!output_exists) {
+                Console.WriteLine("Missing dependency! (" + file + " or " + output + "). Read which files are required in the README");
+                throw new Exception("Missing dependency! (" + file + " or " + output + "). Read which files are required in the README");
+            }
+        }
+
+        public static void CheckFile(string file) {
+            if (!File.Exists(file)) {
+                throw new Exception("Missing dependency! (" + file + "). Read which files are required in the README");
+            }
+        }
+    }
+}

--- a/ServerInit.cs
+++ b/ServerInit.cs
@@ -17,7 +17,7 @@ namespace AMP.DedicatedServer {
         internal static string serverIcon = "";
         internal static string gamemode_override = "";
 
-        static void Main(string[] args) {
+        public static void Start(CommandLine cmd) {
             Log.loggerType = Log.LoggerType.CONSOLE;
             Netamite.Logging.Log.loggerType = Netamite.Logging.Log.LoggerType.EVENT_ONLY;
 
@@ -59,16 +59,12 @@ namespace AMP.DedicatedServer {
             uint max_players = (uint) serverConfig.serverSettings.max_players;
             string password  = serverConfig.serverSettings.password;
 
-            if(args.Length > 0) {
-                port = ushort.Parse(args[0]);
+            if (cmd.HasArg("port")) {
+                port = ushort.Parse(cmd.GetArg("port"));
+            }
 
-                if(args.Length > 1) {
-                    max_players = uint.Parse(args[1]);
-
-                    if(args.Length > 2) {
-                        password = args[2];
-                    }
-                }
+            if (cmd.HasArg("max_players")) {
+                max_players = uint.Parse(cmd.GetArg("max_players"));
             }
 
             if(File.Exists("icon.jpg")) {


### PR DESCRIPTION
Changes:
[+] Added a new command line system
Allows one to use `-port 1234` or `-max_players 16` without having to use any order or requiring the other one  
[+] Added the AMP.Bootstrap.Launcher class
- Automatically Renames ZZZ_AMP.dll to AMP.dll  
- Checks if dependencies exist before starting  
- Handles any errors on Startup and writes them into an errors.txt file   

[#] Added `loadFromRemoteSources` to App.config  
Fixes Netamite.Steam.dll throwing `System.NotSupportedException`   
[#] Fixed spawnitem command description  

I tested it with the public and beta version and on Linux and everything should work fine.  
The new command line system also supports the old arguments which were ([port] [max_players])